### PR TITLE
Remove unused variables from CameraView

### DIFF
--- a/MedidorOticaApp/MedidorOticaApp/Views/CameraView.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Views/CameraView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 import AVFoundation
-import Vision
 import UIKit
 import ARKit
 
@@ -19,9 +18,7 @@ struct CameraView: View {
     @StateObject private var verificationManager = VerificationManager.shared
     
     // Estados da interface
-    @State private var isCaptureEnabled = true
     @State private var isAutoCaptureEnabled = false
-    @State private var instructionText = "Posicione seu rosto no oval"
     @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var capturedImage: UIImage?


### PR DESCRIPTION
## Summary
- clean up `CameraView` by removing unused `Vision` import and state properties

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686547d47b88832788fb53786af1a028