### PR TITLE
Fix verification reset and tracking

### DIFF
--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ConfiguracaoDispositivo.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ConfiguracaoDispositivo.swift
@@ -79,7 +79,9 @@ extension CameraManager {
         cameraPosition = position
         self.arSession = arSession
         self.arSession?.delegate = self
-        isUsingARSession = (arSession != nil)
+        DispatchQueue.main.async {
+            self.isUsingARSession = (arSession != nil)
+        }
 
         isUsingARSession ? configureARSession(completion) : configureCaptureSession(completion)
     }

--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ControleSessao.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ControleSessao.swift
@@ -48,6 +48,7 @@ extension CameraManager {
         }
 
         isSessionRunning = false
+        VerificationManager.shared.reset()
     }
 
     private func stopARSession() {

--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager.swift
@@ -48,6 +48,8 @@ class CameraManager: NSObject, ObservableObject {
     @Published var isSessionRunning = false
     @Published private(set) var hasTrueDepth = false
     @Published private(set) var hasLiDAR = false
+    /// Indica se a sessão atual utiliza ARKit (TrueDepth ou LiDAR)
+    @Published var isUsingARSession = false
 
     /// Callback invocado a cada novo frame AR
     public var outputDelegate: ((ARFrame) -> Void)?
@@ -60,7 +62,6 @@ class CameraManager: NSObject, ObservableObject {
     var videoDeviceInput: AVCaptureDeviceInput?
     var currentPhotoCaptureProcessor: PhotoCaptureProcessor?
     var arSession: ARSession?
-    var isUsingARSession = false
 
     // MARK: - Initialization
     private override init() {
@@ -110,5 +111,12 @@ class CameraManager: NSObject, ObservableObject {
 extension CameraManager: ARSessionDelegate {
     func session(_ session: ARSession, didUpdate frame: ARFrame) {
         outputDelegate?(frame)
+    }
+
+    func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
+        if case .normal = camera.trackingState { return }
+
+        // Quando o rastreamento não está normal, reseta verificações
+        VerificationManager.shared.reset()
     }
 }

--- a/MedidorOticaApp/MedidorOticaApp/Managers/VerificationManager.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/VerificationManager.swift
@@ -40,7 +40,7 @@ class VerificationManager: ObservableObject {
     @Published var hasLiDAR = false // Indica se o dispositivo tem sensor LiDAR
     
     // Compatibilidade com código antigo
-    @Published var faceCentered: Bool = false // Para compatiblidade com código antigo
+    @Published var faceCentered: Bool = false // Compatibilidade com código antigo
     @Published var gazeData: [String: Float] = [:] // Para compatiblidade com código antigo
     @Published var alignmentData: [String: Float] = [:] // Para compatiblidade com código antigo
     @Published var facePosition: [String: Float] = [:] // Para compatiblidade com código antigo
@@ -187,6 +187,10 @@ class VerificationManager: ObservableObject {
     func processARFrame(_ frame: ARFrame) {
         guard case .normal = frame.camera.trackingState else {
             print("Aviso: Rastreamento da câmera não está no estado normal: \(frame.camera.trackingState)")
+            resetAllVerifications()
+            DispatchQueue.main.async { [weak self] in
+                self?.updateVerificationStatus()
+            }
             return
         }
 
@@ -229,23 +233,34 @@ class VerificationManager: ObservableObject {
     
     /// Redefine todas as verificações para o estado inicial
     private func resetAllVerifications() {
-        faceDetected = false
-        distanceCorrect = false
-        faceAligned = false
-        headAligned = false
-        frameDetected = false
-        frameAligned = false
-        gazeCorrect = false
-        
-        // Atualiza a lista de verificações
-        for i in 0..<verifications.count {
-            verifications[i].isChecked = false
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.faceDetected = false
+            self.distanceCorrect = false
+            self.faceAligned = false
+            self.headAligned = false
+            self.frameDetected = false
+            self.frameAligned = false
+            self.gazeCorrect = false
+            self.faceCentered = false
+
+            // Atualiza a lista de verificações
+            for i in 0..<self.verifications.count {
+                self.verifications[i].isChecked = false
+            }
         }
     }
 
     
     /// Método público para atualizar as verificações a partir de extensões
     func updateAllVerifications() {
+        updateVerificationStatus()
+    }
+
+    /// Permite resetar todas as verificações externamente
+    func reset() {
+        resetAllVerifications()
         updateVerificationStatus()
     }
     

--- a/MedidorOticaApp/MedidorOticaApp/Views/CameraComponents.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Views/CameraComponents.swift
@@ -70,12 +70,16 @@ struct CameraPreview: UIViewRepresentable {
 }
 
 // MARK: - Preview para ARSession
+/// Exibe a visualização de uma `ARSession` mantendo o `delegate` informado.
 struct ARCameraPreview: UIViewRepresentable {
     let session: ARSession
+    let delegate: ARSessionDelegate
 
     func makeUIView(context: Context) -> ARSCNView {
         let view = ARSCNView(frame: UIScreen.main.bounds)
         view.session = session
+        // Garante que o delegate permaneça atribuído ao CameraManager
+        view.session.delegate = delegate
         view.automaticallyUpdatesLighting = true
         view.backgroundColor = .black
         return view
@@ -83,6 +87,7 @@ struct ARCameraPreview: UIViewRepresentable {
 
     func updateUIView(_ uiView: ARSCNView, context: Context) {
         uiView.session = session
+        uiView.session.delegate = delegate
         uiView.frame = UIScreen.main.bounds
     }
 }

--- a/MedidorOticaApp/MedidorOticaApp/Views/CameraView.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Views/CameraView.swift
@@ -47,7 +47,7 @@ struct CameraView: View {
             // Preview da câmera ou AR
             Group {
                 if cameraManager.isUsingARSession, let arSession = cameraManager.arSession {
-                    ARCameraPreview(session: arSession)
+                    ARCameraPreview(session: arSession, delegate: cameraManager)
                 } else {
                     CameraPreview(session: cameraManager.session)
                 }


### PR DESCRIPTION
## Summary
- reset `faceCentered` when cleaning verification flags
- expose public `reset()` method to reuse from other managers
- reset verifications when camera stops and when AR tracking loses precision

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68670e9430648327993ff96e97a0915a