### PR TITLE
Add distance overlay

### DIFF
--- a/MedidorOticaApp/MedidorOticaApp/Views/CameraComponents.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Views/CameraComponents.swift
@@ -171,7 +171,9 @@ struct CameraHighlight: View {
 // MARK: - Oval com barra de progresso
 struct ProgressOval: View {
     let verificationManager: VerificationManager
-    
+    /// Define se a distância deve ser exibida abaixo do oval.
+    var showDistance: Bool = false
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -192,6 +194,13 @@ struct ProgressOval: View {
                     .stroke(Color.green, lineWidth: 3)
                     .frame(width: 300, height: 400)
                     .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+
+                // Distância exibida abaixo do oval, caso habilitada
+                if showDistance {
+                    DistanceOverlay(verificationManager: verificationManager)
+                        .position(x: geometry.size.width / 2,
+                                  y: geometry.size.height / 2 + 230)
+                }
             }
         }
     }

--- a/MedidorOticaApp/MedidorOticaApp/Views/CameraView.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Views/CameraView.swift
@@ -27,6 +27,8 @@ struct CameraView: View {
     @State private var showingResultView = false
     @State private var showVerifications = true // Mostrar verificações por padrão
     @State private var cameraInitialized = false
+    /// Define se o medidor de distância deve ser exibido.
+    private let showDistanceOverlay = true
 
     // Observadores de notificações adicionados dinamicamente
     @State private var notificationObservers: [NSObjectProtocol] = []
@@ -137,7 +139,8 @@ struct CameraView: View {
             }
             
             // Oval centralizado com barra de progresso
-            ProgressOval(verificationManager: verificationManager)
+            ProgressOval(verificationManager: verificationManager,
+                         showDistance: showDistanceOverlay)
             
             // Overlay de controles (usando um VStack para elementos de interface)
             VStack {

--- a/MedidorOticaApp/MedidorOticaApp/Views/DistanceOverlay.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Views/DistanceOverlay.swift
@@ -1,0 +1,24 @@
+//
+//  DistanceOverlay.swift
+//  MedidorOticaApp
+//
+//  Exibe a distância atual entre o usuário e a câmera.
+//  Pode ser facilmente ativada ou removida.
+//
+
+import SwiftUI
+
+/// View opcional que mostra a distância medida.
+struct DistanceOverlay: View {
+    @ObservedObject var verificationManager: VerificationManager
+
+    var body: some View {
+        Text(String(format: "%.1f cm", verificationManager.lastMeasuredDistance))
+            .font(.headline)
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .background(Color.black.opacity(0.6))
+            .cornerRadius(8)
+    }
+}


### PR DESCRIPTION
## Summary
- create `DistanceOverlay` to easily show or remove distance info
- allow `ProgressOval` to optionally display this overlay
- toggle the overlay from `CameraView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68684b4e58508327a03fe37b32f1bfb3