### PR TITLE
Corrige AR para camera traseira

### DIFF
--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ControleSessao.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ControleSessao.swift
@@ -23,9 +23,13 @@ extension CameraManager {
             return config
         } else if ARWorldTrackingConfiguration.isSupported {
             let config = ARWorldTrackingConfiguration()
-            if #available(iOS 13.4, *), ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {
-                config.sceneReconstruction = .mesh
-                config.frameSemantics.insert(.sceneDepth)
+            if #available(iOS 13.4, *) {
+                if ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {
+                    config.sceneReconstruction = .mesh
+                }
+                if ARWorldTrackingConfiguration.supportsFrameSemantics(.sceneDepth) {
+                    config.frameSemantics.insert(.sceneDepth)
+                }
             }
             print("Usando ARWorldTrackingConfiguration")
             return config
@@ -66,9 +70,13 @@ extension CameraManager {
                     throw NSError(domain: "ARError", code: 1002, userInfo: [NSLocalizedDescriptionKey: configurationError ?? "Erro desconhecido"])
                 }
                 let worldConfig = ARWorldTrackingConfiguration()
-                if ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {
-                    worldConfig.sceneReconstruction = .mesh
-                    worldConfig.frameSemantics.insert(.sceneDepth)
+                if #available(iOS 13.4, *) {
+                    if ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {
+                        worldConfig.sceneReconstruction = .mesh
+                    }
+                    if ARWorldTrackingConfiguration.supportsFrameSemantics(.sceneDepth) {
+                        worldConfig.frameSemantics.insert(.sceneDepth)
+                    }
                     print("Configurando sessão AR com LiDAR para profundidade")
                 }
                 configuration = worldConfig


### PR DESCRIPTION
## Resumo
- garante habilitacao de `sceneDepth` mesmo sem `sceneReconstruction`
- atualiza configuracao AR ao alternar para camera traseira

## Testes
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686fcdae583c83278cc9471f8fecd1f9