### PR TITLE
Fix photo orientation and restart AR session

### DIFF
--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+CapturaFoto.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+CapturaFoto.swift
@@ -39,7 +39,9 @@ extension CameraManager {
             return
         }
 
-        let image = UIImage(cgImage: cgImage)
+        // Ajusta a orientação da imagem conforme a posição da câmera
+        let orientation: UIImage.Orientation = cameraPosition == .front ? .leftMirrored : .right
+        let image = UIImage(cgImage: cgImage, scale: 1.0, orientation: orientation)
         print("Imagem capturada da sessão AR com sucesso")
         DispatchQueue.main.async { completion(image) }
     }

--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ControleSessao.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager+ControleSessao.swift
@@ -140,4 +140,23 @@ extension CameraManager {
         session.commitConfiguration()
         videoDeviceInput = nil
     }
+
+    /// Reinicia a sessão atual após interrupções ou falhas
+    func restartSession() {
+        if isUsingARSession {
+            let configuration = createARConfiguration()
+            arSession?.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+            isSessionRunning = true
+            print("Sessão AR reiniciada")
+        } else {
+            sessionQueue.async { [weak self] in
+                guard let self = self else { return }
+                if !self.session.isRunning {
+                    self.session.startRunning()
+                    DispatchQueue.main.async { self.isSessionRunning = true }
+                    print("Sessão da câmera reiniciada")
+                }
+            }
+        }
+    }
 }

--- a/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/CameraManager.swift
@@ -136,9 +136,14 @@ extension CameraManager: ARSessionDelegate {
 
     func session(_ session: ARSession, didFailWithError error: Error) {
         publishARError("Sessão AR falhou: \(error.localizedDescription)")
+        restartSession()
     }
 
     func sessionWasInterrupted(_ session: ARSession) {
         publishARError("Sessão AR interrompida")
+    }
+
+    func sessionInterruptionEnded(_ session: ARSession) {
+        restartSession()
     }
 }

--- a/MedidorOticaApp/MedidorOticaApp/Verifications/DepthUtils.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Verifications/DepthUtils.swift
@@ -41,13 +41,19 @@ extension VerificationManager {
                        y: sumY / CGFloat(points.count))
     }
 
-    /// Retorna a orientação atual do dispositivo para uso no Vision
+    /// Retorna a orientação atual considerando a posição da câmera
     func currentCGOrientation() -> CGImagePropertyOrientation {
+        let position = CameraManager.shared.cameraPosition
+
         switch UIDevice.current.orientation {
-        case .landscapeLeft:  return .up
-        case .landscapeRight: return .down
-        case .portraitUpsideDown: return .left
-        default: return .right
+        case .landscapeLeft:
+            return position == .front ? .downMirrored : .up
+        case .landscapeRight:
+            return position == .front ? .upMirrored : .down
+        case .portraitUpsideDown:
+            return position == .front ? .rightMirrored : .left
+        default:
+            return position == .front ? .leftMirrored : .right
         }
     }
 

--- a/MedidorOticaApp/MedidorOticaApp/Verifications/HeadAlignmentVerification.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Verifications/HeadAlignmentVerification.swift
@@ -27,11 +27,15 @@ extension VerificationManager {
         let pitchDegrees: Float
 
         if hasTrueDepth, let anchor = faceAnchor {
-            // Extrai os ângulos diretamente do anchor, método mais confiável
-            let euler = extractEulerAngles(from: anchor.transform)
+            // Extrai ângulos relativos à câmera para evitar desalinhamentos
+            let worldToCamera = simd_inverse(frame.camera.transform)
+            let faceToCamera = simd_mul(worldToCamera, anchor.transform)
+            let euler = extractEulerAngles(from: faceToCamera)
 
-            rollDegrees  = radiansToDegrees(euler.roll)
-            yawDegrees   = radiansToDegrees(euler.yaw)
+            let sign: Float = CameraManager.shared.cameraPosition == .front ? -1 : 1
+
+            rollDegrees  = radiansToDegrees(euler.roll) * sign
+            yawDegrees   = radiansToDegrees(euler.yaw) * sign
             pitchDegrees = radiansToDegrees(euler.pitch)
         } else if hasLiDAR, let angles = headAnglesWithVision(from: frame) {
             rollDegrees = angles.roll


### PR DESCRIPTION
## Summary
- orient captured images based on camera position
- return orientation for Vision taking camera position into account
- allow camera/AR sessions to restart after interruption
- restart session when AR errors occur
- adjust head alignment angles relative to camera

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_687e7ec8741483278d948dfddb332ea7