### PR TITLE
Fix FrameLandmarks initializer

### DIFF
--- a/MedidorOticaApp/MedidorOticaApp/Managers/VerificationManager.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Managers/VerificationManager.swift
@@ -11,7 +11,8 @@ import AVFoundation
 import ARKit
 import Combine
 
-class VerificationManager: ObservableObject {
+/// Gerencia todas as verificações de medição óptica.
+final class VerificationManager: ObservableObject {
     static let shared = VerificationManager()
 
     // Publicação das verificações para a interface
@@ -372,3 +373,6 @@ class VerificationManager: ObservableObject {
         hasLiDAR = manager.hasLiDAR
     }
 }
+
+
+extension VerificationManager: @unchecked Sendable {}

--- a/MedidorOticaApp/MedidorOticaApp/Models/FrameLandmarks.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Models/FrameLandmarks.swift
@@ -9,6 +9,7 @@ import CoreGraphics
 
 /// Representa linhas verticais e horizontais que delimitam a armação.
 struct FrameLandmarks {
+    // MARK: - Propriedades
     /// Linha vertical à esquerda (0 a 1) que delimita a lente esquerda
     var leftLineX: CGFloat
 
@@ -26,4 +27,37 @@ struct FrameLandmarks {
 
     /// Centro da pupila direita, normalizado entre 0 e 1
     var rightPupil: CGPoint
+
+    /// Largura normalizada da armação
+    var width: CGFloat { rightLineX - leftLineX }
+
+    /// Altura normalizada da armação
+    var height: CGFloat { bottomLineY - topLineY }
+
+    /// Inicializador que recebe valores normalizados das linhas e pupilas.
+    init(leftLineX: CGFloat, rightLineX: CGFloat, topLineY: CGFloat, bottomLineY: CGFloat, leftPupil: CGPoint, rightPupil: CGPoint) {
+        self.leftLineX = leftLineX
+        self.rightLineX = rightLineX
+        self.topLineY = topLineY
+        self.bottomLineY = bottomLineY
+        self.leftPupil = leftPupil
+        self.rightPupil = rightPupil
+    }
+
+    /// Inicializador de compatibilidade utilizando pontos absolutos.
+    /// - Parameters:
+    ///   - leftPoint: Lado esquerdo da armação.
+    ///   - rightPoint: Lado direito da armação.
+    ///   - topPoint: Linha superior da armação.
+    ///   - bottomPoint: Linha inferior da armação.
+    ///   - leftPupil: Centro da pupila esquerda.
+    ///   - rightPupil: Centro da pupila direita.
+    init(leftPoint: CGPoint, rightPoint: CGPoint, topPoint: CGPoint, bottomPoint: CGPoint, leftPupil: CGPoint, rightPupil: CGPoint) {
+        self.leftLineX = leftPoint.x
+        self.rightLineX = rightPoint.x
+        self.topLineY = topPoint.y
+        self.bottomLineY = bottomPoint.y
+        self.leftPupil = leftPupil
+        self.rightPupil = rightPupil
+    }
 }

--- a/MedidorOticaApp/MedidorOticaApp/Verifications/FrameAnalyzer.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Verifications/FrameAnalyzer.swift
@@ -101,4 +101,3 @@ private extension CGImagePropertyOrientation {
         }
     }
 }
-*** End of File ***

--- a/MedidorOticaApp/MedidorOticaApp/Verifications/PupilTracking.swift
+++ b/MedidorOticaApp/MedidorOticaApp/Verifications/PupilTracking.swift
@@ -18,11 +18,11 @@ extension VerificationManager {
     func updatePupilPoints(using frame: ARFrame) {
         let orientation = currentCGOrientation()
         processingQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let (left, right) = self.detectPupils(in: frame, orientation: orientation)
-            DispatchQueue.main.async {
-                self.leftPupilPoint = left
-                self.rightPupilPoint = right
+            Task { @MainActor [weak self] in
+                self?.leftPupilPoint = left
+                self?.rightPupilPoint = right
             }
         }
     }
@@ -41,7 +41,7 @@ extension VerificationManager {
     }
 
     // MARK: - Implementação privada
-    private func detectPupils(in frame: ARFrame,
+    nonisolated private func detectPupils(in frame: ARFrame,
                               orientation: CGImagePropertyOrientation) -> (CGPoint?, CGPoint?) {
         let buffer = frame.capturedImage
         let (width, height) = orientedDimensions(for: buffer, orientation: orientation)


### PR DESCRIPTION
## Summary
- add explicit initializer using normalized line positions
- make VerificationManager final and mark as @unchecked Sendable
- update pupil tracking to use Task on main actor and mark detection as nonisolated
- refine FrameLandmarks with computed width and height

## Testing
- `swift --version`
- `find MedidorOticaApp/MedidorOticaApp -name '*.swift' -print0 | xargs -0 swiftc -parse`


------
https://chatgpt.com/codex/tasks/task_e_68878d5739a88327ba640f5c5adece3c